### PR TITLE
Lock Elixir Bundle to a specific version.

### DIFF
--- a/Casks/tm-elixir.rb
+++ b/Casks/tm-elixir.rb
@@ -1,11 +1,11 @@
 cask "tm-elixir" do
-  version :latest
-  sha256 :no_check
+  version "1b4315ffd8e01769c254f5f5dbccc23cc469a6b8"
+  sha256 "6b6277aae39bfb78ea22d99d923adda8f5c242b74aca3433278f5a24d4ea2fa3"
 
-  url "https://github.com/elixir-lang/elixir-tmbundle/archive/master.tar.gz"
+  url "https://github.com/elixir-lang/elixir-tmbundle/archive/#{version}.tar.gz"
 
   name "A TextMate Bundle for the Elixir programming language."
   homepage "https://github.com/elixir-lang/elixir-tmbundle"
 
-  tmbundle "elixir-tmbundle-master", target: "Elixir.tmbundle"
+  tmbundle "elixir-tmbundle-#{version}", target: "Elixir.tmbundle"
 end


### PR DESCRIPTION
This allows us to check that the file we expect to download is in fact
the bundle that we are downloading.